### PR TITLE
ignore http error

### DIFF
--- a/get_emojis.py
+++ b/get_emojis.py
@@ -12,10 +12,13 @@ SLACK_URL = 'https://{slack}.slack.com/api/emoji.list?token={token}'
 
 
 def download_image(url, path):
-    r = requests.get(url, stream=True)
-    with open(path, 'wb') as f:
-        for chunk in r.iter_content():
-            f.write(chunk)
+    try:
+        r = requests.get(url, stream=True)
+        with open(path, 'wb') as f:
+            for chunk in r.iter_content():
+                f.write(chunk)
+    except ValueError:
+        print "Oops! " + url + " could not get from slack."
 
 
 def reconcile_aliases(image_url, emoji):


### PR DESCRIPTION
If slack's emoji alias was broken, the following error appears. So requiring error handling.


```
Traceback (most recent call last):
  File "get_emojis.py", line 54, in <module>
    main(args)
  File "get_emojis.py", line 41, in main
    download_image(image_url, image_path)
  File "get_emojis.py", line 15, in download_image
    r = requests.get(url, stream=True)
  File "/Users/b06193/.pyenv/versions/2.7.11/lib/python2.7/site-packages/requests/api.py", line 71, in get
    return request('get', url, params=params, **kwargs)
  File "/Users/b06193/.pyenv/versions/2.7.11/lib/python2.7/site-packages/requests/api.py", line 57, in request
    return session.request(method=method, url=url, **kwargs)
  File "/Users/b06193/.pyenv/versions/2.7.11/lib/python2.7/site-packages/requests/sessions.py", line 475, in request
    resp = self.send(prep, **send_kwargs)
  File "/Users/b06193/.pyenv/versions/2.7.11/lib/python2.7/site-packages/requests/sessions.py", line 579, in send
    adapter = self.get_adapter(url=request.url)
  File "/Users/b06193/.pyenv/versions/2.7.11/lib/python2.7/site-packages/requests/sessions.py", line 653, in get_adapter
    raise InvalidSchema("No connection adapters were found for '%s'" % url)
requests.exceptions.InvalidSchema: No connection adapters were found for 'alias:ace'
```